### PR TITLE
Make compatible with the new command registry

### DIFF
--- a/lib/command-palette-view.coffee
+++ b/lib/command-palette-view.coffee
@@ -37,7 +37,7 @@ class CommandPaletteView extends SelectListView
     else
       commands = []
       for eventName, eventDescription of _.extend($(window).events(), @eventElement.events())
-        commands.push({name: eventName, displayName: eventDescription}) if eventDescription
+        commands.push({name: eventName, displayName: eventDescription, jQuery: true}) if eventDescription
 
     commands = _.sortBy(commands, 'displayName')
     @setItems(commands)
@@ -54,6 +54,9 @@ class CommandPaletteView extends SelectListView
             @kbd _.humanizeKeystroke(binding.keystrokes), class: 'key-binding'
         @span displayName, title: name
 
-  confirmed: ({name}) ->
+  confirmed: ({name, jQuery}) ->
     @cancel()
-    @eventElement[0].dispatchEvent(new CustomEvent(name))
+    if jQuery
+      @eventElement.trigger name
+    else
+      @eventElement[0].dispatchEvent(new CustomEvent(name))


### PR DESCRIPTION
This PR is compatible with versions of Atom without the command registry as well, so its specs will keep passing on the current released version. Once we release the command registry, we can come back and remove support for the old paths.
