### PR TITLE
Show and search full command names

### DIFF
--- a/lib/command-palette-view.coffee
+++ b/lib/command-palette-view.coffee
@@ -52,11 +52,12 @@ class CommandPaletteView extends SelectListView
   viewForItem: ({name, displayName, eventDescription}) ->
     keyBindings = @keyBindings
     $$ ->
-      @li class: 'event', 'data-event-name': name, =>
+      @li class: 'event two-lines', 'data-event-name': name, =>
         @div class: 'pull-right', =>
           for binding in keyBindings when binding.command is name
             @kbd _.humanizeKeystroke(binding.keystrokes), class: 'key-binding'
-        @span displayName, title: name
+        @div displayName, class: 'primary-line', title: name
+        @div name, class: 'secondary-line', title: name
 
   confirmed: ({name}) ->
     @cancel()

--- a/spec/command-palette-spec.coffee
+++ b/spec/command-palette-spec.coffee
@@ -30,8 +30,10 @@ describe "CommandPalette", ->
     for {name, displayName} in atom.commands.findCommands(target: element)
       eventLi = palette.list.children("[data-event-name='#{name}']")
       expect(eventLi).toExist()
-      expect(eventLi.find('span')).toHaveText(displayName)
-      expect(eventLi.find('span').attr('title')).toBe(name)
+      expect(eventLi.find('.primary-line')).toHaveText(displayName)
+      expect(eventLi.find('.primary-line').attr('title')).toBe(name)
+      expect(eventLi.find('.secondary-line')).toHaveText(name)
+      expect(eventLi.find('.secondary-line').attr('title')).toBe(name)
       for binding in keyBindings when binding.command is name
         expect(eventLi.text()).toContain(_.humanizeKeystroke(binding.keystrokes))
 


### PR DESCRIPTION
Resolves #36 
### Before

![screenshot 2015-04-14 10 23 46](https://cloud.githubusercontent.com/assets/823545/7138782/65f8ee5e-e290-11e4-8e78-95dd8b8ce892.png)
### After

![screenshot 2015-04-14 00 09 14](https://cloud.githubusercontent.com/assets/823545/7130243/882de7c8-e23a-11e4-82a0-7a5834329d3d.png)

/cc @atom/non-github-maintainers Anyone wanna take a look?
/cc @l4u
