### PR TITLE
Add match highlighting for commands

### DIFF
--- a/lib/command-palette-view.coffee
+++ b/lib/command-palette-view.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 {SelectListView, $, $$} = require 'atom-space-pen-views'
+{match} = require 'fuzzaldrin'
 
 module.exports =
 class CommandPaletteView extends SelectListView
@@ -51,12 +52,36 @@ class CommandPaletteView extends SelectListView
 
   viewForItem: ({name, displayName, eventDescription}) ->
     keyBindings = @keyBindings
+    # Style matched characters in search results
+    filterQuery = @getFilterQuery()
+    matches = match(displayName, filterQuery)
+
     $$ ->
+      highlighter = (command, matches, offsetIndex) =>
+        lastIndex = 0
+        matchedChars = [] # Build up a set of matched chars to be more semantic
+
+        for matchIndex in matches
+          matchIndex -= offsetIndex
+          continue if matchIndex < 0 # If marking up the basename, omit command matches
+          unmatched = command.substring(lastIndex, matchIndex)
+          if unmatched
+            @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+            matchedChars = []
+            @text unmatched
+          matchedChars.push(command[matchIndex])
+          lastIndex = matchIndex + 1
+
+        @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+
+        # Remaining characters are plain text
+        @text command.substring(lastIndex)
+
       @li class: 'event', 'data-event-name': name, =>
         @div class: 'pull-right', =>
           for binding in keyBindings when binding.command is name
             @kbd _.humanizeKeystroke(binding.keystrokes), class: 'key-binding'
-        @span displayName, title: name
+        @span title: name, -> highlighter(displayName, matches, 0)
 
   confirmed: ({name}) ->
     @cancel()

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
+    "fuzzaldrin": "^2.1.0",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {

--- a/spec/command-palette-spec.coffee
+++ b/spec/command-palette-spec.coffee
@@ -90,3 +90,35 @@ describe "CommandPalette", ->
       document.body.focus()
       atom.commands.dispatch(workspaceElement, 'command-palette:toggle')
       expectCommandsForElement(workspaceElement)
+
+  describe "match highlighting", ->
+    beforeEach ->
+      jasmine.attachToDOM(workspaceElement)
+
+    it "highlights an exact match", ->
+      palette.filterEditorView.getModel().setText('Application: About')
+      palette.populateList()
+      resultView = palette.getSelectedItemView()
+
+      matches = resultView.find('.character-match')
+      expect(matches.length).toBe 1
+      expect(matches.last().text()).toBe 'Application: About'
+
+    it "highlights a partial match", ->
+      palette.filterEditorView.getModel().setText('Application')
+      palette.populateList()
+      resultView = palette.getSelectedItemView()
+
+      matches = resultView.find('.character-match')
+      expect(matches.length).toBe 1
+      expect(matches.last().text()).toBe 'Application'
+
+    it "highlights multiple matches in the file name", ->
+      palette.filterEditorView.getModel().setText('ApplicationAbout')
+      palette.populateList()
+      resultView = palette.getSelectedItemView()
+
+      matches = resultView.find('.character-match')
+      expect(matches.length).toBe 2
+      expect(matches.first().text()).toBe 'Application'
+      expect(matches.last().text()).toBe 'About'

--- a/styles/command-palette.less
+++ b/styles/command-palette.less
@@ -1,7 +1,9 @@
 @import "ui-variables";
 
 // Highlight matched text
-.select-list .list-group .character-match {
-  color: @text-color-highlight;
-  font-weight: bold;
+.command-palette {
+  .select-list .list-group .character-match {
+    color: @text-color-highlight;
+    font-weight: bold;
+  }
 }

--- a/styles/command-palette.less
+++ b/styles/command-palette.less
@@ -1,9 +1,7 @@
 @import "ui-variables";
 
 // Highlight matched text
-.command-palette {
-  .select-list .list-group .character-match {
-    color: @text-color-highlight;
-    font-weight: bold;
-  }
+.command-palette .list-group .character-match {
+  color: @text-color-highlight;
+  font-weight: bold;
 }

--- a/styles/command-palette.less
+++ b/styles/command-palette.less
@@ -1,0 +1,7 @@
+@import "ui-variables";
+
+// Highlight matched text
+.select-list .list-group .character-match {
+  color: @text-color-highlight;
+  font-weight: bold;
+}


### PR DESCRIPTION
This adds match highlighting for commands in the Command Palette:

![screenshot 2015-05-14 12 58 35](https://cloud.githubusercontent.com/assets/823545/7637040/03eedfc8-fa39-11e4-93f0-15254bc73a34.png)

(Thanks @philschatz for the implementation in fuzzy-finder!)