### PR TITLE
Add fuzzaldrin-plus as an option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "fuzzaldrin": "^2.1.0",
+    "fuzzaldrin-plus": "^0.1.0",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add fuzzaldrin-plus as an option.
Address https://github.com/atom/command-palette/issues/59

This try to replicate https://github.com/atom/fuzzy-finder/pull/142 but for command palette.



Including the ugly part where we copy / paste some of 
atom-space-pen-views > select-list-view # [populateList](https://github.com/atom/atom-space-pen-views/blob/master/src/select-list-view.coffee#L161).

If this live long enougth for maintenance to be a concern we could split the data and presentation part. For example we could move [those lines](https://github.com/atom/atom-space-pen-views/blob/master/src/select-list-view.coffee#L164-L169) to a `filterList` / `populateData` method. So we could later override only the data.
