### PR TITLE
Add preserve last search setting and config option

### DIFF
--- a/spec/command-palette-spec.coffee
+++ b/spec/command-palette-spec.coffee
@@ -50,6 +50,14 @@ describe "CommandPalette", ->
       atom.commands.dispatch(workspaceElement, 'command-palette:toggle')
       expect(palette.filterEditorView.getText()).toBe ''
 
+  describe "when command-palette:toggle is triggered and the preserveLastSearch setting is enabled", ->
+    it "preserves the previous mini editor text", ->
+      atom.config.set('command-palette.preserveLastSearch', true)
+      palette.filterEditorView.setText('hello')
+      palette.cancel()
+      atom.commands.dispatch(workspaceElement, 'command-palette:toggle')
+      expect(palette.filterEditorView.getText()).toBe 'hello'
+
   describe "when command-palette:toggle is triggered on the open command palette", ->
     it "focus the root view and hides the command palette", ->
       expect(palette.isVisible()).toBeTruthy()


### PR DESCRIPTION
Adds an option which is accessible through the settings to preserve the last text entered into the command palette. This has been extended and improved from here: https://github.com/atom/command-palette/issues/46#issuecomment-125390750

<img width="446" alt="screen shot 2016-05-17 at 22 51 16" src="https://cloud.githubusercontent.com/assets/7351557/15340545/e2485f22-1c81-11e6-9e7c-02d1fc4426aa.png">
