### PR TITLE
Remove 'Experimental' from alternate scoring definition

### DIFF
--- a/lib/command-palette-view.coffee
+++ b/lib/command-palette-view.coffee
@@ -10,7 +10,7 @@ class CommandPaletteView extends SelectListView
     useAlternateScoring:
       type: 'boolean'
       default: true
-      description: 'Use an alternative scoring approach which prefers run of consecutive characters, acronyms and start of words. (Experimental)'
+      description: 'Use an alternative scoring approach which prefers run of consecutive characters, acronyms and start of words.'
 
   @activate: ->
     view = new CommandPaletteView


### PR DESCRIPTION
Since the "alternate" scoring is the default now, we should remove the "Experimental" label from the description.