### PR TITLE
Change 'OSX' to 'macOS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Command Palette package
-[![OS X Build Status](https://travis-ci.org/atom/command-palette.svg?branch=master)](https://travis-ci.org/atom/command-palette) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/jqgwetayr0enorun/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/command-palette/branch/master) [![Dependency Status](https://david-dm.org/atom/command-palette.svg)](https://david-dm.org/atom/command-palette)
+[![macOS Build Status](https://travis-ci.org/atom/command-palette.svg?branch=master)](https://travis-ci.org/atom/command-palette) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/jqgwetayr0enorun/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/command-palette/branch/master) [![Dependency Status](https://david-dm.org/atom/command-palette.svg)](https://david-dm.org/atom/command-palette)
 
 Find and run available commands using <kbd>cmd-shift-p</kbd> (macOS) or <kbd>ctrl-shift-p</kbd> (Linux/Windows) in Atom.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Command Palette package
 [![OS X Build Status](https://travis-ci.org/atom/command-palette.svg?branch=master)](https://travis-ci.org/atom/command-palette) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/jqgwetayr0enorun/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/command-palette/branch/master) [![Dependency Status](https://david-dm.org/atom/command-palette.svg)](https://david-dm.org/atom/command-palette)
 
-Find and run available commands using <kbd>cmd-shift-p</kbd> (OSX) or <kbd>ctrl-shift-p</kbd> (Linux/Windows) in Atom.
+Find and run available commands using <kbd>cmd-shift-p</kbd> (macOS) or <kbd>ctrl-shift-p</kbd> (Linux/Windows) in Atom.
 
 ![](https://f.cloud.github.com/assets/671378/2241354/2908b768-9ccd-11e3-9da1-a11753c0495d.png)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "command-palette",
   "version": "0.38.0",
   "main": "./lib/command-palette-view",
-  "description": "Find and run available commands using `cmd-shift-p` (OSX) or `ctrl-shift-p` (Linux/Windows).",
+  "description": "Find and run available commands using `cmd-shift-p` (macOS) or `ctrl-shift-p` (Linux/Windows).",
   "activationCommands": {
     "atom-workspace": [
       "command-palette:toggle"


### PR DESCRIPTION
I've changed 'OSX' to 'macOS' in two files: package.json and README.md.
This is in line with Apple's new macOS Sierra and other Atom commits, like atom/atom@0ceacf5c13bb37eecd8147592fbb2533067522a1

This is my first contribution to Atom, so any feedback is welcome!