### PR TITLE
Add MaxResults config option with default 10

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -16,6 +16,9 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
+    this.disposables.add(atom.config.observe('command-palette.maxResults', (newValue) => {
+      this.commandPaletteView.update({maxResults: newValue})
+    }))
     return this.commandPaletteView.show()
   }
 

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -106,17 +106,11 @@ export default class CommandPaletteView {
       this.selectListView.refs.queryEditor.selectAll()
     }
 
-    console.time('collect');
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
-    console.timeEnd('collect');
-    console.time('render');
     await this.selectListView.update({items: this.commandsForActiveElement})
-    console.timeEnd('render');
-    console.log('item length', this.commandsForActiveElement.length);
-    console.log('-----------');
 
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
@@ -135,9 +129,11 @@ export default class CommandPaletteView {
     if (props.hasOwnProperty('preserveLastSearch')) {
       this.preserveLastSearch = props.preserveLastSearch
     }
+
     if (props.hasOwnProperty('maxResults') ) {
       await this.selectListView.update({maxResults: props.maxResults})
     }
+
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
       if (this.useAlternateScoring) {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -106,11 +106,17 @@ export default class CommandPaletteView {
       this.selectListView.refs.queryEditor.selectAll()
     }
 
+    console.time('collect');
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
+    console.timeEnd('collect');
+    console.time('render');
     await this.selectListView.update({items: this.commandsForActiveElement})
+    console.timeEnd('render');
+    console.log('item length', this.commandsForActiveElement.length);
+    console.log('-----------');
 
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
@@ -129,7 +135,9 @@ export default class CommandPaletteView {
     if (props.hasOwnProperty('preserveLastSearch')) {
       this.preserveLastSearch = props.preserveLastSearch
     }
-
+    if (props.hasOwnProperty('maxResults') ) {
+      await this.selectListView.update({maxResults: props.maxResults})
+    }
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
       if (this.useAlternateScoring) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "type": "boolean",
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
+    },
+    "maxResults": {
+      "default": 100000,
+      "minimum": 1,
+      "description": "Number of items",
+      "type": "integer"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
       "description": "Preserve the last search when reopening the command palette."
     },
     "maxResults": {
-      "default": 100000,
+      "type": "integer",
+      "default": 10,
       "minimum": 1,
-      "description": "Number of items",
-      "type": "integer"
+      "description": "Number of items to appears on select-list"
     }
   }
 }

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -125,10 +125,9 @@ describe('CommandPaletteView', () => {
 
     it("Limit items added to select-list with specified `maxResults` value", async () => {
       const commandPalette = new CommandPaletteView()
+      await commandPalette.toggle()
       await commandPalette.update({maxResults: 5})
-      await commandPalette.toggle()
       assert.equal(commandPalette.selectListView.items.length, 5)
-      await commandPalette.toggle()
       await commandPalette.update({maxResults: 1})
       assert.equal(commandPalette.selectListView.items.length, 1)
     })

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -122,6 +122,16 @@ describe('CommandPaletteView', () => {
       assert.equal(document.activeElement.closest('atom-text-editor'), editor.element)
       assert.equal(commandPalette.selectListView.element.offsetHeight, 0)
     })
+
+    it("Limit items added to select-list with specified `maxResults` value", async () => {
+      const commandPalette = new CommandPaletteView()
+      await commandPalette.update({maxResults: 5})
+      await commandPalette.toggle()
+      assert.equal(commandPalette.selectListView.items.length, 5)
+      await commandPalette.toggle()
+      await commandPalette.update({maxResults: 1})
+      assert.equal(commandPalette.selectListView.items.length, 1)
+    })
   })
 
   describe('when selecting a command', () => {


### PR DESCRIPTION
### Description of the Change

- When many commands are added, `command-palette:toggle` become non responsive.
- This PR add `MaxResults` options with default `10`, which make `command-palette:toggle` more responsive even after hundreds commands are added.

- New `MaxResults` config option, with default value `10`.
  - Control how many items to be added on select-list.
  - By limiting items to render to `MaxResults`, it reduce rendering time and make command-palette more responsive.

- This PR introduce breaking change since it truncate items to `10` by default.
  - In previous release, all commands are added on select-list.
  - This difference become obvious only when user **scroll** items in the the select-list.
  - Since without scrolling, items just visible is just `7` in bundled UI themes(`one-dark`, `atom-dark` etc).

- Because main use-case of `command-palette` is narrow items by `fuzzy-search` by keyboard, adding non-visible items is just add extra delay in most situation.
- So I set it's default to `10`.

- Even if this breaking change was not acceptable, I want this PR merged with different default value.

# Background

When many commands are registered via community packages, `command-palette:toggle` become a little sluggish.
- E.g.
  - Install tons of packages.
  - Install packages which add hundreds of commands(such as `vim-mode-plus`).

# How much improve responsiveness by this PRs.

Here is the result collected at this commit(https://github.com/atom/command-palette/commit/44fd635585506608cf25e765eca69921e05e3d77) by following steps.

1. From `source.gfm` editor, start command-palette by `cmd-shift-p`.
2. Observe console.log output to see how much time it took to `collect` items, and `render` items.
3. `collect` + `render` time is roughly the time command-palette shows up in UX perspective.

- My PC's spec is here.

```
$ sysctl -n machdep.cpu.brand_string
Intel(R) Core(TM) i5-6267U CPU @ 2.90GHz
$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.12.4
BuildVersion:   16E195
add-max-results-option github/command-palette%
```

## No community packages( Atoms default )

- MaxResults: 10000( No limit )

```
collect: 16.730ms
render: 44.497ms
item length 375
-----------
collect: 13.186ms
render: 35.304ms
item length 375
-----------
collect: 11.761ms
render: 36.046ms
item length 375
-----------
```

- MaxResult: 50

```
collect: 14.101ms
render: 3.281ms
item length 375
-----------
collect: 13.299ms
render: 2.925ms
item length 375
-----------
collect: 12.891ms
render: 3.091ms
item length 375
-----------
```

- MaxResults: 10

```
collect: 13.229ms
render: 1.930ms
item length 375
-----------
collect: 13.957ms
render: 1.862ms
item length 375
-----------
collect: 13.206ms
render: 1.648ms
item length 375
-----------
```

### Some packages installed

- installed community packages

```
one-dark-vivid-syntax: 1.7.1
atomic-chrome: 0.3.0
choose-pane: 0.7.0
clip-history: 0.4.0
cursor-history: 0.10.1
linter: 2.1.4
linter-ui-default: 1.3.0
markdown-toc-auto: 0.7.0
quick-highlight: 0.10.0
vim-mode-plus: 0.92.0
vim-mode-plus-keymaps-for-surround: 0.2.1
recent-finder: 0.5.1
```

- MaxResults: 10000( No limit )

```
collect: 22.079ms
render: 77.315ms
item length 846
-----------
collect: 24.637ms
render: 87.127ms
item length 846
-----------
collect: 23.875ms
render: 107.473ms
item length 846
-----------```
```

- MaxResults: 50

```
collect: 24.011ms
render: 5.482ms
item length 848
-----------
collect: 20.187ms
render: 4.475ms
item length 848
-----------
collect: 22.080ms
render: 4.981ms
item length 848
-----------
```

- MaxResults: 10

```
collect: 23.265ms
render: 2.192ms
item length 848
-----------
collect: 23.262ms
render: 1.897ms
item length 848
-----------
collect: 23.693ms
render: 1.849ms
item length 848
-----------
```

### Alternate Designs

No alternate design I considered.

### Benefits

`command-palette:toggle` get more responsive by default, I believe it also make overall Atom's performance impression better.

### Possible Drawbacks

Results items on select-list is truncated to 10 items by default.
When user scroll over items on select-list, user can see only 10 commands( in previous release user could see all available commands ).

### Applicable Issues

Fix #80
Related #35
