### PR TITLE
Display command metadata (description, tags) when available

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -20,7 +20,7 @@ export default class CommandPaletteView {
 
         const rightBlock = document.createElement('div')
         rightBlock.classList.add('pull-right')
-        let i = 0;
+        let i = 0
         for (const keyBinding of this.keyBindingsForActiveElement) {
           if (keyBinding.command === item.name) {
             const kbd = document.createElement('kbd')
@@ -38,10 +38,10 @@ export default class CommandPaletteView {
         leftBlock.appendChild(titleEl)
 
         const query = this.selectListView.getQuery()
-        this.highlightMatchesInElement(item.displayName, query, titleEl);
+        this.highlightMatchesInElement(item.displayName, query, titleEl)
 
         if (selected) {
-          let secondaryEl = document.createElement('div');
+          let secondaryEl = document.createElement('div')
           secondaryEl.classList.add('secondary-line')
           secondaryEl.style.display = 'flex'
 
@@ -61,7 +61,7 @@ export default class CommandPaletteView {
             }
           }
 
-          leftBlock.appendChild(secondaryEl);
+          leftBlock.appendChild(secondaryEl)
         }
 
         li.appendChild(leftBlock)
@@ -94,7 +94,7 @@ export default class CommandPaletteView {
 
   async show () {
     if (!this.panel) {
-      this.panel = atom.workspace.addModalPanel({ item: this.selectListView })
+      this.panel = atom.workspace.addModalPanel({item: this.selectListView})
     }
 
     if (!this.preserveLastSearch) {
@@ -109,7 +109,7 @@ export default class CommandPaletteView {
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
     await this.selectListView.update({items: this.commandsForActiveElement})
 
-    this.previouslyFocusedElement = document.activeElement;
+    this.previouslyFocusedElement = document.activeElement
     this.panel.show()
     this.selectListView.focus()
   }
@@ -117,8 +117,8 @@ export default class CommandPaletteView {
   hide () {
     this.panel.hide()
     if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus();
-      this.previouslyFocusedElement = null;
+      this.previouslyFocusedElement.focus()
+      this.previouslyFocusedElement = null
     }
   }
 
@@ -176,7 +176,7 @@ export default class CommandPaletteView {
       return items
     }
 
-    const scoredItems = [];
+    const scoredItems = []
     for (const item of items) {
       let score = this.fuzz.score(item.displayName, query)
       if (item.tags) {
@@ -215,7 +215,7 @@ export default class CommandPaletteView {
   }
 
   createTag (tagText, query) {
-    const tagEl = document.createElement('li');
+    const tagEl = document.createElement('li')
     Object.assign(tagEl.style, {
       borderBottom: 0,
       display: 'inline',

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -11,63 +11,60 @@ export default class CommandPaletteView {
     this.commandsForActiveElement = []
     this.selectListView = new SelectListView({
       items: this.commandsForActiveElement,
+      filter: this.filter,
       emptyMessage: 'No matches found',
-      filterKeyForItem: (item) => item.displayName,
-      elementForItem: ({name, displayName}) => {
+      elementForItem: (item, {index, selected}) => {
         const li = document.createElement('li')
-        li.classList.add('event')
-        li.dataset.eventName = name
+        li.classList.add('event', 'two-lines')
+        li.dataset.eventName = item.name
 
-        const div = document.createElement('div')
-        div.classList.add('pull-right')
+        const rightBlock = document.createElement('div')
+        rightBlock.classList.add('pull-right')
+        let i = 0;
         for (const keyBinding of this.keyBindingsForActiveElement) {
-          if (keyBinding.command === name) {
+          if (keyBinding.command === item.name) {
             const kbd = document.createElement('kbd')
             kbd.classList.add('key-binding')
             kbd.textContent = humanizeKeystroke(keyBinding.keystrokes)
-            div.appendChild(kbd)
+            rightBlock.appendChild(kbd)
           }
         }
-        li.appendChild(div)
+        li.appendChild(rightBlock)
 
-        const span = document.createElement('span')
-        span.title = name
+        const leftBlock = document.createElement('div')
+        const titleEl = document.createElement('div')
+        titleEl.classList.add('primary-line')
+        titleEl.title = item.name
+        leftBlock.appendChild(titleEl)
 
         const query = this.selectListView.getQuery()
-        const matches = this.useAlternateScoring ? fuzzaldrinPlus.match(displayName, query) : fuzzaldrin.match(displayName, query)
-        let matchedChars = []
-        let lastIndex = 0
-        for (const matchIndex of matches) {
-          const unmatched = displayName.substring(lastIndex, matchIndex)
-          if (unmatched) {
-            if (matchedChars.length > 0) {
-              const matchSpan = document.createElement('span')
-              matchSpan.classList.add('character-match')
-              matchSpan.textContent = matchedChars.join('')
-              span.appendChild(matchSpan)
-              matchedChars = []
-            }
+        this.highlightMatchesInElement(item.displayName, query, titleEl);
 
-            span.appendChild(document.createTextNode(unmatched))
+        if (selected) {
+          let secondaryEl = document.createElement('div');
+          secondaryEl.classList.add('secondary-line')
+          secondaryEl.style.display = 'flex'
+
+          if (typeof item.description === 'string') {
+            secondaryEl.appendChild(this.createDescription(item.description, query))
           }
 
-          matchedChars.push(displayName[matchIndex])
-          lastIndex = matchIndex + 1
+          if (Array.isArray(item.tags)) {
+            const matchingTags = item.tags
+              .map(t => [t, this.fuzz.score(t, query)])
+              .filter(([t, s]) => s > 0)
+              .sort((a, b) => a.s - b.s)
+              .map(([t, s]) => t)
+
+            if (matchingTags.length > 0) {
+              secondaryEl.appendChild(this.createTags(matchingTags, query))
+            }
+          }
+
+          leftBlock.appendChild(secondaryEl);
         }
 
-        if (matchedChars.length > 0) {
-          const matchSpan = document.createElement('span')
-          matchSpan.classList.add('character-match')
-          matchSpan.textContent = matchedChars.join('')
-          span.appendChild(matchSpan)
-        }
-
-        const unmatched = displayName.substring(lastIndex)
-        if (unmatched) {
-          span.appendChild(document.createTextNode(unmatched))
-        }
-
-        li.appendChild(span)
+        li.appendChild(leftBlock)
         return li
       },
       didConfirmSelection: (keyBinding) => {
@@ -97,7 +94,7 @@ export default class CommandPaletteView {
 
   async show () {
     if (!this.panel) {
-      this.panel = atom.workspace.addModalPanel({item: this.selectListView})
+      this.panel = atom.workspace.addModalPanel({ item: this.selectListView })
     }
 
     if (!this.preserveLastSearch) {
@@ -112,7 +109,7 @@ export default class CommandPaletteView {
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
     await this.selectListView.update({items: this.commandsForActiveElement})
 
-    this.previouslyFocusedElement = document.activeElement
+    this.previouslyFocusedElement = document.activeElement;
     this.panel.show()
     this.selectListView.focus()
   }
@@ -120,8 +117,8 @@ export default class CommandPaletteView {
   hide () {
     this.panel.hide()
     if (this.previouslyFocusedElement) {
-      this.previouslyFocusedElement.focus()
-      this.previouslyFocusedElement = null
+      this.previouslyFocusedElement.focus();
+      this.previouslyFocusedElement = null;
     }
   }
 
@@ -132,15 +129,123 @@ export default class CommandPaletteView {
 
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
-      if (this.useAlternateScoring) {
-        await this.selectListView.update({
-          filter: (items, query) => {
-            return query ? fuzzaldrinPlus.filter(items, query, {key: 'displayName'}) : items
-          }
-        })
-      } else {
-        await this.selectListView.update({filter: null})
+    }
+  }
+
+  get fuzz () {
+    return this.useAlternateScoring ? fuzzaldrinPlus : fuzzaldrin
+  }
+
+  highlightMatchesInElement (text, query, el) {
+    const matches = this.fuzz.match(text, query)
+    let matchedChars = []
+    let lastIndex = 0
+    for (const matchIndex of matches) {
+      const unmatched = text.substring(lastIndex, matchIndex)
+      if (unmatched) {
+        if (matchedChars.length > 0) {
+          const matchSpan = document.createElement('span')
+          matchSpan.classList.add('character-match')
+          matchSpan.textContent = matchedChars.join('')
+          el.appendChild(matchSpan)
+          matchedChars = []
+        }
+
+        el.appendChild(document.createTextNode(unmatched))
+      }
+
+      matchedChars.push(text[matchIndex])
+      lastIndex = matchIndex + 1
+    }
+
+    if (matchedChars.length > 0) {
+      const matchSpan = document.createElement('span')
+      matchSpan.classList.add('character-match')
+      matchSpan.textContent = matchedChars.join('')
+      el.appendChild(matchSpan)
+    }
+
+    const unmatched = text.substring(lastIndex)
+    if (unmatched) {
+      el.appendChild(document.createTextNode(unmatched))
+    }
+  }
+
+  filter = (items, query) => {
+    if (query.length === 0) {
+      return items
+    }
+
+    const scoredItems = [];
+    for (const item of items) {
+      let score = this.fuzz.score(item.displayName, query)
+      if (item.tags) {
+        score += item.tags.reduce(
+          (currentScore, tag) => currentScore + this.fuzz.score(tag, query),
+          0
+        )
+      }
+      if (item.description) {
+        score += this.fuzz.score(item.description, query)
+      }
+
+      if (score > 0) {
+        scoredItems.push({item, score})
       }
     }
+    scoredItems.sort((a, b) => b.score - a.score)
+    return scoredItems.map((i) => i.item)
+  }
+
+  createDescription (description, query) {
+    const descriptionEl = document.createElement('div')
+
+    // in case of overflow, give full contents on long hover
+    descriptionEl.title = description
+
+    Object.assign(descriptionEl.style, {
+      flexGrow: 1,
+      flexShrink: 1,
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden'
+    })
+    this.highlightMatchesInElement(description, query, descriptionEl)
+    return descriptionEl
+  }
+
+  createTag (tagText, query) {
+    const tagEl = document.createElement('li');
+    Object.assign(tagEl.style, {
+      borderBottom: 0,
+      display: 'inline',
+      padding: 0
+    })
+    this.highlightMatchesInElement(tagText, query, tagEl)
+    return tagEl
+  }
+
+  createTags (matchingTags, query) {
+    const tagsEl = document.createElement('ol')
+    Object.assign(tagsEl.style, {
+      display: 'inline',
+      marginLeft: '4px',
+      flexShrink: 0,
+      padding: 0
+    })
+
+    const introEl = document.createElement('strong')
+    introEl.textContent = 'matching tags: '
+
+    tagsEl.appendChild(introEl)
+    matchingTags.map(t => this.createTag(t, query)).forEach((tagEl, i) => {
+      tagsEl.appendChild(tagEl)
+      if (i < matchingTags.length - 1) {
+        const commaSpace = document.createElement('span')
+        commaSpace.textContent = ', '
+        tagsEl.appendChild(commaSpace)
+      }
+    })
+    return tagsEl
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
   },
   "atomTestRunner": "atom-mocha-test-runner",
   "dependencies": {
-    "atom-select-list": "^0.1.0",
+    "atom-select-list": "github:atom/atom-select-list#073f0955d51b568baa7191a89a9d0b1979a039ac",
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.4.1",
     "underscore-plus": "^1.0.0"
   },
   "devDependencies": {
     "atom-mocha-test-runner": "^0.3.0",
-    "coffeelint": "^1.9.7"
+    "coffeelint": "^1.9.7",
+    "sinon": "^3.2.1"
   },
   "configSchema": {
     "useAlternateScoring": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "atom-mocha-test-runner": "^0.3.0",
     "coffeelint": "^1.9.7",
+    "semver": "^5.4.1",
     "sinon": "^3.2.1"
   },
   "configSchema": {

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -16,12 +16,12 @@ describe('CommandPaletteView', () => {
         'foo:with-description': {
           displayName: 'A Custom Display Name',
           description: 'Awesome description here',
-          onDidDispatch() {}
+          onDidDispatch () {}
         },
         'foo:with-tags': {
           displayName: 'A Custom Display Name',
           tags: ['bar', 'baz'],
-          onDidDispatch() {}
+          onDidDispatch () {}
         }
       }
     )
@@ -50,13 +50,17 @@ describe('CommandPaletteView', () => {
 
         const keyBindings = atom.keymaps.findKeyBindings({target: editor.element})
         for (const item of atom.commands.findCommands({target: editor.element})) {
-          const {name, description, displayName, tags} = item;
+          const {name, description, displayName, tags} = item
           const eventLi = workspaceElement.querySelector(`[data-event-name='${name}']`)
-          const displayNameLine = eventLi.querySelector('.primary-line');
+          const displayNameLine = eventLi.querySelector('.primary-line')
           assert.equal(displayNameLine.textContent, displayName)
           assert.equal(displayNameLine.title, name)
 
           if (description) {
+            // just in case it's not the first, need to select the item in order
+            // for its description to show
+            await commandPalette.selectListView.selectItem(item)
+
             const descriptionEl = eventLi.querySelector('.secondary-line div')
             assert(descriptionEl)
             assert.equal(descriptionEl.textContent, description)
@@ -172,7 +176,7 @@ describe('CommandPaletteView', () => {
   })
 
   describe('match highlighting', () => {
-    it("highlights exact matches", async () => {
+    it('highlights exact matches', async () => {
       const commandPalette = new CommandPaletteView()
       await commandPalette.toggle()
       commandPalette.selectListView.refs.queryEditor.setText('Application: About')
@@ -182,7 +186,7 @@ describe('CommandPaletteView', () => {
       assert.equal(matches[0].textContent, 'Application: About')
     })
 
-    it("highlights partial matches in the displayName", async () => {
+    it('highlights partial matches in the displayName', async () => {
       const commandPalette = new CommandPaletteView()
       await commandPalette.toggle()
       commandPalette.selectListView.refs.queryEditor.setText('Application')
@@ -194,12 +198,12 @@ describe('CommandPaletteView', () => {
       }
     })
 
-    it("highlights partial matches in the description", async () => {
+    it('highlights partial matches in the description', async () => {
       const commandPalette = new CommandPaletteView()
       await commandPalette.toggle()
       commandPalette.selectListView.refs.queryEditor.setText('Awesome')
       await commandPalette.selectListView.update()
-      const {element} = commandPalette.selectListView;
+      const {element} = commandPalette.selectListView
 
       const withDescriptionLi = element.querySelector(`[data-event-name='foo:with-description']`)
       const matches = withDescriptionLi.querySelectorAll('.character-match')
@@ -207,12 +211,12 @@ describe('CommandPaletteView', () => {
       assert.equal(matches[0].textContent, 'Awesome')
     })
 
-    it("highlights partial matches in the tags", async () => {
+    it('highlights partial matches in the tags', async () => {
       const commandPalette = new CommandPaletteView()
       await commandPalette.toggle()
       commandPalette.selectListView.refs.queryEditor.setText('bar')
       await commandPalette.selectListView.update()
-      const {element} = commandPalette.selectListView;
+      const {element} = commandPalette.selectListView
 
       const withTagsLi = element.querySelector(`[data-event-name='foo:with-tags']`)
       const matches = withTagsLi.querySelectorAll('.character-match')
@@ -220,7 +224,7 @@ describe('CommandPaletteView', () => {
       assert.equal(matches[0].textContent, 'bar')
     })
 
-    it("highlights multiple matches in the command name", async () => {
+    it('highlights multiple matches in the command name', async () => {
       const commandPalette = new CommandPaletteView()
       await commandPalette.toggle()
       commandPalette.selectListView.refs.queryEditor.setText('ApplicationAbout')


### PR DESCRIPTION
This adds support to Atom's command palette to display a command's description when it's currently selected. It will also show relevant "tags" (basicaly synonyms or keywords) only when they match the user's query (like the macOS "Settings" vs "Preferences" behavior referenced by the PR below)

A gif speaks the best :)

![command-palette-with-description-tags](https://user-images.githubusercontent.com/755844/29651550-207bdbc0-8856-11e7-856c-18adf5096925.gif)

Currently this uses a git sha for `atom-select-list`, where I recently added support for passing through the `selected` state of each item to `elementForItem`. We'll need to publish that before merging this.

This also depends on [the rich metadata listeners PR over in atom/atom](https://github.com/atom/atom/pull/15383)

Released Under CC0.

cc @iolsen @nathansobo @matthewwithanm @jinface @karincurkowicz