### PR TITLE
Add options to have history commands

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -16,6 +16,13 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
+    this.disposables.add(atom.config.observe('command-palette.historyCommands', (newValue) => {
+      this.commandPaletteView.update({historyCommands: newValue})
+    }))
+    this.disposables.add(atom.config.observe('command-palette.maxHistoryCommands', (newValue) => {
+      this.commandPaletteView.update({maxHistoryCommands: newValue})
+    }))
+
     return this.commandPaletteView.show()
   }
 

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -70,12 +70,15 @@ export default class CommandPaletteView {
       },
       didConfirmSelection: (keyBinding) => {
         this.hide()
-        if (this.recentCommands.indexOf(keyBinding.name) === -1) {
-          this.recentCommands.unshift(keyBinding.name)
-          this.recentCommands.splice(10, 2);
-        } else {
-          this.recentCommands = this.recentCommands.sort((x,y) => x == keyBinding.name ? -1 : y == keyBinding.name ? 1 : 0);
+        if (this.historyCommands) {
+          if (this.recentCommands.indexOf(keyBinding.name) === -1) {
+            this.recentCommands.unshift(keyBinding.name)
+            this.recentCommands.splice(this.maxHistoryCommands, 1);
+          } else {
+            this.recentCommands = this.recentCommands.sort((x,y) => x == keyBinding.name ? -1 : y == keyBinding.name ? 1 : 0);
+          }
         }
+
         const event = new CustomEvent(keyBinding.name, {bubbles: true, cancelable: true})
         this.activeElement.dispatchEvent(event)
       },
@@ -113,20 +116,25 @@ export default class CommandPaletteView {
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
-    this.commandsForActiveElement = this.commandsForActiveElement.sort((x,y) => {
-      var indexX = this.recentCommands.indexOf(x.name);
-      var indexY = this.recentCommands.indexOf(y.name);
-      if (indexX !== -1 && indexY !== -1) {
-        return indexX > indexY
-      }
-      else if (indexX !== -1){
-        return -1
-      }
-      else if (indexY !== -1){
-        return 1
-      }
-      return x.displayName.localeCompare(y.displayName)
-    });
+    if (this.historyCommands) {
+      this.commandsForActiveElement.sort((x,y) => {
+        var indexX = this.recentCommands.indexOf(x.name);
+        var indexY = this.recentCommands.indexOf(y.name);
+        if (indexX !== -1 && indexY !== -1) {
+          return indexX > indexY
+        }
+        else if (indexX !== -1){
+          return -1
+        }
+        else if (indexY !== -1){
+          return 1
+        }
+        return x.displayName.localeCompare(y.displayName)
+      });
+    } else {
+      this.commandsForActiveElement.sort((a,b) => a.displayName.localeCompare(b.displayName));
+    }
+
 
     await this.selectListView.update({items: this.commandsForActiveElement})
 
@@ -146,6 +154,14 @@ export default class CommandPaletteView {
   async update (props) {
     if (props.hasOwnProperty('preserveLastSearch')) {
       this.preserveLastSearch = props.preserveLastSearch
+    }
+
+    if (props.hasOwnProperty('historyCommands')) {
+      this.historyCommands = props.historyCommands
+    }
+
+    if (props.hasOwnProperty('maxHistoryCommands')) {
+      this.maxHistoryCommands = props.maxHistoryCommands
     }
 
     if (props.hasOwnProperty('useAlternateScoring')) {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -9,6 +9,7 @@ export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
     this.commandsForActiveElement = []
+    this.recentCommands = []
     this.selectListView = new SelectListView({
       items: this.commandsForActiveElement,
       filter: this.filter,
@@ -69,6 +70,12 @@ export default class CommandPaletteView {
       },
       didConfirmSelection: (keyBinding) => {
         this.hide()
+        if (this.recentCommands.indexOf(keyBinding.name) === -1) {
+          this.recentCommands.unshift(keyBinding.name)
+          this.recentCommands.splice(10, 2);
+        } else {
+          this.recentCommands = this.recentCommands.sort((x,y) => x == keyBinding.name ? -1 : y == keyBinding.name ? 1 : 0);
+        }
         const event = new CustomEvent(keyBinding.name, {bubbles: true, cancelable: true})
         this.activeElement.dispatchEvent(event)
       },
@@ -106,7 +113,21 @@ export default class CommandPaletteView {
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
-    this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
+    this.commandsForActiveElement = this.commandsForActiveElement.sort((x,y) => {
+      var indexX = this.recentCommands.indexOf(x.name);
+      var indexY = this.recentCommands.indexOf(y.name);
+      if (indexX !== -1 && indexY !== -1) {
+        return indexX > indexY
+      }
+      else if (indexX !== -1){
+        return -1
+      }
+      else if (indexY !== -1){
+        return 1
+      }
+      return x.displayName.localeCompare(y.displayName)
+    });
+
     await this.selectListView.update({items: this.commandsForActiveElement})
 
     this.previouslyFocusedElement = document.activeElement

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
       "type": "boolean",
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
+    },
+    "historyCommands": {
+      "type": "boolean",
+      "default": false,
+      "description": "Keep command history"
+    },
+    "maxHistoryCommands": {
+      "type": "integer",
+      "default": 10,
+      "description": "Number of history command show on select-list"
     }
   }
 }


### PR DESCRIPTION
I added options to let use to see their history commands in command panel. 

When `historyCommands` set to true, the commands are order in "Latest commands" + "rest of commands" in alphabetical order. 

I also added an option to set how many history commands that user want to see. 

e.g:
![image](https://user-images.githubusercontent.com/2519905/30526615-8f7b9e5e-9beb-11e7-9320-e51ced306067.png)
