### PR TITLE
Improve initial sorting of items [WiP]

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -16,8 +16,8 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
-    this.disposables.add(atom.config.observe('command-palette.preserveMostUsed', (newValue) => {
-      this.commandPaletteView.update({preserveMostUsed: newValue})
+    this.disposables.add(atom.config.observe('command-palette.initialOrderingOfItems', (newValue) => {
+      this.commandPaletteView.update({initialOrderingOfItems: newValue})
     }))
     return this.commandPaletteView.show()
   }

--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -4,8 +4,8 @@ import {CompositeDisposable} from 'atom'
 import CommandPaletteView from './command-palette-view'
 
 class CommandPalettePackage {
-  activate () {
-    this.commandPaletteView = new CommandPaletteView()
+  activate (state) {
+    this.commandPaletteView = new CommandPaletteView(state)
     this.disposables = new CompositeDisposable()
     this.disposables.add(atom.commands.add('atom-workspace', 'command-palette:toggle', () => {
       this.commandPaletteView.toggle()
@@ -16,7 +16,14 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
+    this.disposables.add(atom.config.observe('command-palette.preserveMostUsed', (newValue) => {
+      this.commandPaletteView.update({preserveMostUsed: newValue})
+    }))
     return this.commandPaletteView.show()
+  }
+
+  serialize() {
+    return this.commandPaletteView.serialize()
   }
 
   async deactivate () {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -39,9 +39,7 @@ export default class CommandPaletteView {
         leftBlock.appendChild(titleEl)
 
         const query = this.selectListView.getQuery()
-        const itemLaunches = this.itemLaunches[item.name] || []
-        const title = `${item.displayName} (${itemLaunches.length})`
-        this.highlightMatchesInElement(title, query, titleEl)
+        this.highlightMatchesInElement(item.displayName, query, titleEl)
 
         if (selected) {
           let secondaryEl = document.createElement('div')
@@ -204,7 +202,7 @@ export default class CommandPaletteView {
           score = launchDates.length
         }
         else if(this.initialOrderingOfItems === "recent") {
-          score = launchDates[0]
+          score = launchDates[launchDates.length-1]
         }
 
         if(score) {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -6,7 +6,8 @@ import fuzzaldrin from 'fuzzaldrin'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
 export default class CommandPaletteView {
-  constructor () {
+  constructor (state) {
+    this.elementScores = state || {}
     this.keyBindingsForActiveElement = []
     this.commandsForActiveElement = []
     this.selectListView = new SelectListView({
@@ -38,7 +39,9 @@ export default class CommandPaletteView {
         leftBlock.appendChild(titleEl)
 
         const query = this.selectListView.getQuery()
-        this.highlightMatchesInElement(item.displayName, query, titleEl)
+        const itemScore = this.elementScores[item.name] || 0
+        const title = `${item.displayName} (${itemScore})`
+        this.highlightMatchesInElement(title, query, titleEl)
 
         if (selected) {
           let secondaryEl = document.createElement('div')
@@ -69,6 +72,14 @@ export default class CommandPaletteView {
       },
       didConfirmSelection: (keyBinding) => {
         this.hide()
+        console.log(keyBinding.displayName)
+        const elementName = keyBinding.name
+        if(this.elementScores.hasOwnProperty(elementName)) {
+          this.elementScores[elementName]++
+        }
+        else {
+          this.elementScores[elementName] = 1
+        }
         const event = new CustomEvent(keyBinding.name, {bubbles: true, cancelable: true})
         this.activeElement.dispatchEvent(event)
       },
@@ -130,6 +141,10 @@ export default class CommandPaletteView {
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
     }
+
+    if (props.hasOwnProperty('preserveMostUsed')) {
+      this.preserveMostUsed = props.preserveMostUsed
+    }
   }
 
   get fuzz () {
@@ -171,9 +186,28 @@ export default class CommandPaletteView {
     }
   }
 
+  serialize = () => {
+    return this.elementScores? this.elementScores: {}
+  }
+
   filter = (items, query) => {
     if (query.length === 0) {
-      return items
+      if (this.preserveMostUsed) {
+        const scoredItems = items
+        .filter(e => this.elementScores[e.name])
+        .map(item => ({
+          item,
+          score: this.elementScores[item.name]
+        }))
+        .sort((a, b) => b.score - a.score)
+
+        return scoredItems
+        .map(i => i.item)
+        .concat(items.filter(e => !!!this.elementScores[e.name]))
+      }
+      else {
+        return items
+      }
     }
 
     const scoredItems = []

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -142,8 +142,8 @@ export default class CommandPaletteView {
       this.useAlternateScoring = props.useAlternateScoring
     }
 
-    if (props.hasOwnProperty('preserveMostUsed')) {
-      this.preserveMostUsed = props.preserveMostUsed
+    if (props.hasOwnProperty('initialOrderingOfItems')) {
+      this.initialOrderingOfItems = props.initialOrderingOfItems
     }
   }
 
@@ -187,12 +187,12 @@ export default class CommandPaletteView {
   }
 
   serialize = () => ({
-      elementScores: this.elementScores
+    elementScores: this.elementScores
   })
 
   filter = (items, query) => {
     if (query.length === 0) {
-      if (this.preserveMostUsed) {
+      if (this.initialOrderingOfItems === "frequency") {
         const scoredItems = []
         const unscoredItems = []
 
@@ -211,6 +211,10 @@ export default class CommandPaletteView {
         .map(i => i.item)
         .concat(unscoredItems)
       }
+      else if(this.initialOrderingOfItems === "recent") {
+        throw new Error("Ordering by recently used is not implemented yet")
+      }
+
       else {
         return items
       }

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -7,7 +7,7 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
 export default class CommandPaletteView {
   constructor (state = {}) {
-    this.elementScores = state.elementScores || {}
+    this.itemLaunches = state.itemLaunches || {}
     this.keyBindingsForActiveElement = []
     this.commandsForActiveElement = []
     this.selectListView = new SelectListView({
@@ -39,8 +39,8 @@ export default class CommandPaletteView {
         leftBlock.appendChild(titleEl)
 
         const query = this.selectListView.getQuery()
-        const itemScore = this.elementScores[item.name] || 0
-        const title = `${item.displayName} (${itemScore})`
+        const itemLaunches = this.itemLaunches[item.name] || []
+        const title = `${item.displayName} (${itemLaunches.length})`
         this.highlightMatchesInElement(title, query, titleEl)
 
         if (selected) {
@@ -72,13 +72,13 @@ export default class CommandPaletteView {
       },
       didConfirmSelection: (keyBinding) => {
         this.hide()
-        console.log(keyBinding.displayName)
         const elementName = keyBinding.name
-        if(this.elementScores.hasOwnProperty(elementName)) {
-          this.elementScores[elementName]++
+        const launchedAt = new Date().getTime()
+        if(this.itemLaunches.hasOwnProperty(elementName)) {
+          this.itemLaunches[elementName].push(launchedAt)
         }
         else {
-          this.elementScores[elementName] = 1
+          this.itemLaunches[elementName] = [launchedAt]
         }
         const event = new CustomEvent(keyBinding.name, {bubbles: true, cancelable: true})
         this.activeElement.dispatchEvent(event)
@@ -187,37 +187,37 @@ export default class CommandPaletteView {
   }
 
   serialize = () => ({
-    elementScores: this.elementScores
+    itemLaunches: this.itemLaunches
   })
 
   filter = (items, query) => {
     if (query.length === 0) {
-      if (this.initialOrderingOfItems === "frequency") {
-        const scoredItems = []
-        const unscoredItems = []
+      if (Object.keys(this.itemLaunches).length === 0) return items;
 
-        for (const item of items) {
-          const score = this.elementScores[item.name]
-          if(score) {
-            scoredItems.push({item, score})
-          }
-          else {
-            unscoredItems.push(item)
-          }
+      const scoredItems = []
+      const unscoredItems = []
+
+      for (const item of items) {
+        const launchDates = this.itemLaunches[item.name] || []
+        let score;
+        if (this.initialOrderingOfItems === "frequency") {
+          score = launchDates.length
+        }
+        else if(this.initialOrderingOfItems === "recent") {
+          score = launchDates[0]
         }
 
-        return scoredItems
-        .sort((a, b) => b.score - a.score)
-        .map(i => i.item)
-        .concat(unscoredItems)
+        if(score) {
+          scoredItems.push({item, score})
+        }
+        else {
+          unscoredItems.push(item)
+        }
       }
-      else if(this.initialOrderingOfItems === "recent") {
-        throw new Error("Ordering by recently used is not implemented yet")
-      }
-
-      else {
-        return items
-      }
+      return scoredItems
+      .sort((a, b) => b.score - a.score)
+      .map(i => i.item)
+      .concat(unscoredItems)
     }
 
     const scoredItems = []

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -6,8 +6,8 @@ import fuzzaldrin from 'fuzzaldrin'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
 export default class CommandPaletteView {
-  constructor (state) {
-    this.elementScores = state || {}
+  constructor (state = {}) {
+    this.elementScores = state.elementScores || {}
     this.keyBindingsForActiveElement = []
     this.commandsForActiveElement = []
     this.selectListView = new SelectListView({
@@ -186,24 +186,30 @@ export default class CommandPaletteView {
     }
   }
 
-  serialize = () => {
-    return this.elementScores? this.elementScores: {}
-  }
+  serialize = () => ({
+      elementScores: this.elementScores
+  })
 
   filter = (items, query) => {
     if (query.length === 0) {
       if (this.preserveMostUsed) {
-        const scoredItems = items
-        .filter(e => this.elementScores[e.name])
-        .map(item => ({
-          item,
-          score: this.elementScores[item.name]
-        }))
-        .sort((a, b) => b.score - a.score)
+        const scoredItems = []
+        const unscoredItems = []
+
+        for (const item of items) {
+          const score = this.elementScores[item.name]
+          if(score) {
+            scoredItems.push({item, score})
+          }
+          else {
+            unscoredItems.push(item)
+          }
+        }
 
         return scoredItems
+        .sort((a, b) => b.score - a.score)
         .map(i => i.item)
-        .concat(items.filter(e => !!!this.elementScores[e.name]))
+        .concat(unscoredItems)
       }
       else {
         return items

--- a/package.json
+++ b/package.json
@@ -40,10 +40,14 @@
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
     },
-    "preserveMostUsed": {
-      "type": "boolean",
-      "default": true,
-      "description": "Show most used commands when opening the command palette."
+    "initialOrderingOfItems": {
+      "type": "string",
+      "default": "frequency",
+      "enum": [
+        {"value": "frequency", "description": "By frequency of use"},
+        {"value": "recent", "description": "By most recently used"}
+      ]
+
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "semver": "^5.4.1",
     "sinon": "^3.2.1"
   },
+  "deserializers": {
+    "commandPalettePackage": "deserialize"
+  },
   "configSchema": {
     "useAlternateScoring": {
       "type": "boolean",
@@ -36,6 +39,11 @@
       "type": "boolean",
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
+    },
+    "preserveMostUsed": {
+      "type": "boolean",
+      "default": true,
+      "description": "Show most used commands when opening the command palette."
     }
   }
 }


### PR DESCRIPTION
Note: No new tests are added yet to back up the changes. I am also intereseted in feedback/proposals for the design. For these reasons, this PR is currently a work in progress.

### Description of the Change

This PR implements some of the functionality proposed in #18, namely a more friendly initial sorting of items in the command palette(_only_ when no query has been entered yet). 

The change introduces two new settings for the package, "order by frequency" and "order by recently launched".
This sorting is applied when no query is entered into the command palette, presenting more useful item choices to the user than the previous alphabetic sorting.
The items that do not have a score(not yet visited) will be listed alphabetically after the items that does.

* "Order by frequency" orders by how frequently a command has been launched
* "Order by recently launched" orders by how recent the command was last launched

The user can choose between these two sorting methods in the settings view.
Any time a command is lanched with the command palette, the timestamp of that launch is pushed to an array of launch timestamps associated with that command. This array is accessed through an object where the command names are the keys(for example `application:about` is a key).
This object is serialized in order to persist the command launch history between application launches.

The length of the array is used to sort by frequency, and the last timestamp in the array is used to sort by recentness.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->
An alternative would be to only sort by frequency, which would make the persistence of the scores more compact.
The proposed version was selected in order to keep enough data to have "most recent" items. It is also extensible to more advanced sorting algorithms, such as weighting results by recentness and frequency together.

### Benefits

<!-- What benefits will be realized by the code change? -->
The user will have faster access to frequently used commands. This will also minimize those moments when you open the command palette and just can't remember what to enter 🙂 

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
The changes introduces serialization of the command palette in order to persist the command scores between sessions.
Because the scores are identified by the unique command issued, for example `application:about`, any changes to these command identifiers will affect the palette. For example, if a package is uninstalled, the command will be unavailable, but not removed from the scores.
 

### Applicable Issues
#18 
<!-- Enter any applicable Issues here -->
