### PR TITLE
change how item score is calculated

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -178,18 +178,22 @@ export default class CommandPaletteView {
 
     const scoredItems = []
     for (const item of items) {
-      let score = this.fuzz.score(item.displayName, query)
+      const displayNameScore = this.fuzz.score(item.displayName, query)
+      let tagScore;
+      let descriptionScore;
+
       if (item.tags) {
-        score += item.tags.reduce(
+        tagScore = item.tags.reduce(
           (currentScore, tag) => currentScore + this.fuzz.score(tag, query),
           0
         )
       }
       if (item.description) {
-        score += this.fuzz.score(item.description, query)
+        descriptionScore = this.fuzz.score(item.description, query)
       }
 
-      if (score > 0) {
+      if (displayNameScore > 0 || tagScore > 0 || descriptionScore > 0) {
+        const score = Math.max(displayNameScore, tagScore, descriptionScore)
         scoredItems.push({item, score})
       }
     }


### PR DESCRIPTION
### Description of the Change

This PR changes the way item scores are calculated when tags and/or a description is available for that item. Previously the scores for the three would be compounded, causing a disadvantage for items that did not have tags and/or a description. This is fixed in this PR by only using the highest score of the three as the actual item score.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
Fixes #88 
