### PR TITLE
add option to hide namespaces

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -16,6 +16,9 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
+    this.disposables.add(atom.config.observe('command-palette.hideNamespaces', (newValue) => {
+      this.commandPaletteView.update({hideNamespaces: newValue});
+    }))
     return this.commandPaletteView.show()
   }
 

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -9,6 +9,7 @@ export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
     this.commandsForActiveElement = []
+    this.hideNamespaces = []
     this.selectListView = new SelectListView({
       items: this.commandsForActiveElement,
       filter: this.filter,
@@ -107,8 +108,14 @@ export default class CommandPaletteView {
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
+    if (this.hideNamespaces.length > 0) {
+      this.commandsForActiveElement = this.commandsForActiveElement.filter((command) => {
+          const namespace = command.name.split(':')[0]
+          return !this.hideNamespaces.includes(namespace)
+      })
+    }
     await this.selectListView.update({items: this.commandsForActiveElement})
-
+    
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
     this.selectListView.focus()
@@ -129,6 +136,13 @@ export default class CommandPaletteView {
 
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
+    }
+
+    if (props.hasOwnProperty('hideNamespaces')) {
+      this.hideNamespaces = props.hideNamespaces
+        .split(',')
+        .map((name) => name.trim())
+        .map((name) => name.toLowerCase())
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       "type": "boolean",
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
+    },
+    "hideNamespaces": {
+      "type": "string",
+      "default": "",
+      "description": "Comma-seperated list of namespaces (e.g. 'core') for which commands will not be shown. (useful for performance reasons)"
     }
   }
 }

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -115,6 +115,28 @@ describe('CommandPaletteView', () => {
       await commandPalette.toggle()
       assert.equal(commandPalette.selectListView.refs.queryEditor.getText(), 'abc')
     })
+    
+    it('hides commands that are prefixed with namespace-names set in `hideNamespaces`', async () => {
+      const editor = await atom.workspace.open()
+      editor.element.focus()
+
+      const commandPalette = new CommandPaletteView()
+      await commandPalette.update({hideNamespaces: ' Core , Editor '})
+      
+      assert.deepEqual(commandPalette.hideNamespaces, ['core', 'editor'])
+      
+      await commandPalette.toggle()
+
+      const items = Array.from(commandPalette.selectListView.refs.items.children)
+        
+      for (const item of items) {
+        const dataEventName = item.getAttribute('data-event-name')
+        const namespace = dataEventName.split(':')[0]
+        
+        assert.notEqual(namespace, 'core')
+        assert.notEqual(namespace, 'editor')
+      }
+    })
 
     it('hides the command palette and focuses the previously active element if the palette was already open', async () => {
       const editor = await atom.workspace.open()


### PR DESCRIPTION
### Description of the Change

This adds a new configuration that takes a comma separated list of namespaces that should be hidden from the palette. A namespace is what comes before the first colon in a command name. If set `this.commandsForActiveElement` is filtered from commands that match any of those namespaces before `this.panel.show` is called.

### Alternate Designs

1. If there is a way to quickly find out from which package a command is coming from that would probably be a preferable solution. 
2. When registering a command a flag could be given that would hide that command from the palette.
3. [Only render the first `x` results.](https://github.com/atom/command-palette/pull/81)

I assume that 1. and 2. need changes to atom's core and how commands are handled. Also I'm not sure about 2. since that takes away control from the user. 3. is tackling this from a different angle but defaulting to a small `x` may confuse users that do try to go through the list.


### Benefits

This helps to reduce the amount of entries rendered to the palette. Some packages register a lot of commands that are only supposed to be used via shortcuts (like [character-table](https://atom.io/packages/character-table) or [vim-mode-plus](https://atom.io/packages/vim-mode-plus)).

In my case I can cut the rendered elements almost in half by hiding everything from `vim-mode-plus`: 424 (vmp) / 1050 (total).

### Possible Drawbacks

Prefixing commands with the package name seems more of a convention. So this only works if the package one's trying to hide the commands from adheres to this convention. That's also why I chose to use the word `namespace` instead of `package`, to make a distinction there, so no one assumes this work on a package level.

### Applicable Issues

#35, #80, #81
