### PR TITLE
Add support for "hidden" commands

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -7,8 +7,13 @@ class CommandPalettePackage {
   activate () {
     this.commandPaletteView = new CommandPaletteView()
     this.disposables = new CompositeDisposable()
-    this.disposables.add(atom.commands.add('atom-workspace', 'command-palette:toggle', () => {
-      this.commandPaletteView.toggle()
+    this.disposables.add(atom.commands.add('atom-workspace', {
+      'command-palette:toggle': () => {
+        this.commandPaletteView.toggle()
+      },
+      'command-palette:show-hidden-commands': () => {
+        this.commandPaletteView.show(true)
+      }
     }))
     this.disposables.add(atom.config.observe('command-palette.useAlternateScoring', (newValue) => {
       this.commandPaletteView.update({useAlternateScoring: newValue})

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -105,7 +105,9 @@ export default class CommandPaletteView {
 
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
-    this.commandsForActiveElement = atom.commands.findCommands({target: this.activeElement})
+    this.commandsForActiveElement = atom.commands
+        .findCommands({target: this.activeElement})
+        .filter(command => !command.hiddenInCommandPalette)
     this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
     await this.selectListView.update({items: this.commandsForActiveElement})
 

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -8,9 +8,8 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
-    this.commandsForActiveElement = []
     this.selectListView = new SelectListView({
-      items: this.commandsForActiveElement,
+      items: [],
       filter: this.filter,
       emptyMessage: 'No matches found',
       elementForItem: (item, {index, selected}) => {
@@ -105,11 +104,11 @@ export default class CommandPaletteView {
 
     this.activeElement = (document.activeElement === document.body) ? atom.views.getView(atom.workspace) : document.activeElement
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
-    this.commandsForActiveElement = atom.commands
+    const commandsForActiveElement = atom.commands
         .findCommands({target: this.activeElement})
         .filter(command => !command.hiddenInCommandPalette)
-    this.commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
-    await this.selectListView.update({items: this.commandsForActiveElement})
+    commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
+    await this.selectListView.update({items: commandsForActiveElement})
 
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -91,7 +91,7 @@ export default class CommandPaletteView {
     }
   }
 
-  async show () {
+  async show (showHiddenCommands = false) {
     if (!this.panel) {
       this.panel = atom.workspace.addModalPanel({item: this.selectListView})
     }
@@ -106,7 +106,7 @@ export default class CommandPaletteView {
     this.keyBindingsForActiveElement = atom.keymaps.findKeyBindings({target: this.activeElement})
     const commandsForActiveElement = atom.commands
         .findCommands({target: this.activeElement})
-        .filter(command => !command.hiddenInCommandPalette)
+        .filter(command => showHiddenCommands === !!command.hiddenInCommandPalette)
     commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
     await this.selectListView.update({items: commandsForActiveElement})
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "atom-mocha-test-runner": "^0.3.0",
     "coffeelint": "^1.9.7",
+    "event-kit": "^2.4.0",
     "semver": "^5.4.1",
     "sinon": "^3.2.1"
   },

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -137,6 +137,24 @@ describe('CommandPaletteView', () => {
     })
   })
 
+  describe('hidden commands', () => {
+    it('does not show commands that are marked as `hiddenInCommandPalette` by default, then *only* shows those commands when showHiddenCommands is invoked', async () => {
+      const commandsDisposable = atom.commands.add('*', 'foo:hidden-in-command-palette', {
+        hiddenInCommandPalette: true,
+        didDispatch () {}
+      })
+
+      const commandPalette = new CommandPaletteView()
+      await commandPalette.toggle()
+
+      assert(!commandPalette.selectListView.props.items.find(item => item.name === 'foo:hidden-in-command-palette'))
+
+      await commandPalette.show(true)
+      assert.equal(commandPalette.selectListView.props.items.length, 1)
+      assert.equal(commandPalette.selectListView.props.items[0].name, 'foo:hidden-in-command-palette')
+    })
+  })
+
   describe('when selecting a command', () => {
     it('hides the palette, then focuses the previously focused element and dispatches the selected command on it', async () => {
       const editor = await atom.workspace.open()
@@ -244,22 +262,6 @@ describe('CommandPaletteView', () => {
         const matches = withTagsLi.querySelectorAll('.character-match')
         assert(matches.length > 0)
         assert.equal(matches[0].textContent, 'bar')
-      })
-
-      it ('doesn\'t show results that are marked `hiddenInCommandPalette`', async () => {
-        disposable.add(atom.commands.add('*', 'foo:hidden-in-command-palette', {
-          hiddenInCommandPalette: true,
-          didDispatch () {}
-        }))
-
-        const commandPalette = new CommandPaletteView()
-        await commandPalette.toggle()
-        commandPalette.selectListView.refs.queryEditor.setText('hidden in command palette')
-        await commandPalette.selectListView.update()
-        const {element} = commandPalette.selectListView
-
-        const li = element.querySelector(`[data-event-name='foo:hidden-in-command-palette']`)
-        assert(li == null)
       })
     })
   })


### PR DESCRIPTION
This allows for commands to opt-into not appear in command palette.

Frequently commands are an implementation detail, or even only a means of providing a keybinding, and do not benefit from being shown and selectable to the user from the command palette.

Options like "Vim Mode Plus: Set Input Char M" can be confusing to the user and cloud high-signal commands from surfacing in command palette results.

Additionally, showing so many commands can [bog down the command palette and make it slow to start](https://github.com/atom/command-palette/issues/80) -- though there are certainly other means of improving its performance.

The name (`hiddenInCommandPalette`) is the most concise I could come up with to convey what we want here. There might be other ways of surfacing commands in an interface that might not want to obey this (or those that might), but for now I'm erring on the side of being specific to command palette. Totally open to making this more generic if there's a good argument or I'm missing something.

Released under CC0.