### PR TITLE
Cache element items on creation

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -8,11 +8,22 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
+    this.selectedElementCache = new WeakMap()
+    this.plainElementCache = new WeakMap()
     this.selectListView = new SelectListView({
       items: [],
       filter: this.filter,
       emptyMessage: 'No matches found',
       elementForItem: (item, {index, selected}) => {
+        const query = this.selectListView.getQuery()
+        if(query.length === 0) {
+          if(selected && this.selectedElementCache.has(item)) {
+            return this.selectedElementCache.get(item)
+          } else if(!selected && this.plainElementCache.has(item)) {
+            return this.plainElementCache.get(item)
+          }
+        }
+
         const li = document.createElement('li')
         li.classList.add('event', 'two-lines')
         li.dataset.eventName = item.name
@@ -36,7 +47,6 @@ export default class CommandPaletteView {
         titleEl.title = item.name
         leftBlock.appendChild(titleEl)
 
-        const query = this.selectListView.getQuery()
         this.highlightMatchesInElement(item.displayName, query, titleEl)
 
         if (selected) {
@@ -64,6 +74,13 @@ export default class CommandPaletteView {
         }
 
         li.appendChild(leftBlock)
+        if(query.length === 0) {
+          if(selected) {
+            this.selectedElementCache.set(item, li)
+          } else {
+            this.plainElementCache.set(item, li)
+          }
+        }
         return li
       },
       didConfirmSelection: (keyBinding) => {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -8,20 +8,20 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
-    this.selectedElementCache = new WeakMap()
-    this.plainElementCache = new WeakMap()
+    this.elementCache = new WeakMap()
     this.selectListView = new SelectListView({
       items: [],
       filter: this.filter,
       emptyMessage: 'No matches found',
       elementForItem: (item, {index, selected}) => {
         const query = this.selectListView.getQuery()
-        if(query.length === 0) {
-          if(selected && this.selectedElementCache.has(item)) {
-            return this.selectedElementCache.get(item)
-          } else if(!selected && this.plainElementCache.has(item)) {
-            return this.plainElementCache.get(item)
+        const bufferKey = `${query}:${selected}`
+        if(this.elementCache.has(item)) {
+          if(this.elementCache.get(item).has(bufferKey)) {
+            return this.elementCache.get(item).get(bufferKey)
           }
+        } else {
+          this.elementCache.set(item, new Map())
         }
 
         const li = document.createElement('li')
@@ -74,13 +74,7 @@ export default class CommandPaletteView {
         }
 
         li.appendChild(leftBlock)
-        if(query.length === 0) {
-          if(selected) {
-            this.selectedElementCache.set(item, li)
-          } else {
-            this.plainElementCache.set(item, li)
-          }
-        }
+        this.elementCache.get(item).set(bufferKey, li)
         return li
       },
       didConfirmSelection: (keyBinding) => {

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -15,10 +15,10 @@ export default class CommandPaletteView {
       emptyMessage: 'No matches found',
       elementForItem: (item, {index, selected}) => {
         const query = this.selectListView.getQuery()
-        const bufferKey = `${query}:${selected}`
+        const queryKey = `${query}:${selected}`
         if(this.elementCache.has(item)) {
-          if(this.elementCache.get(item).has(bufferKey)) {
-            return this.elementCache.get(item).get(bufferKey)
+          if(this.elementCache.get(item).has(queryKey)) {
+            return this.elementCache.get(item).get(queryKey)
           }
         } else {
           this.elementCache.set(item, new Map())
@@ -74,7 +74,7 @@ export default class CommandPaletteView {
         }
 
         li.appendChild(leftBlock)
-        this.elementCache.get(item).set(bufferKey, li)
+        this.elementCache.get(item).set(queryKey, li)
         return li
       },
       didConfirmSelection: (keyBinding) => {


### PR DESCRIPTION
Continuing from atom/atom-select-list/pull/21. The gist of it is: cetain performance issues in command-palette is caused by the fact that `elementForItem` is invoked for every item whenever the list state is updated, causing command-palette to create and recreate every DOM element more often than needed.

A simple solution to the problem, which is implemented in this PR, is to cache item elements on creation. Items are cached and added incrementally as the selection or query changes.