### PR TITLE
Use cached elements when reactivating palette [fix]

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -8,7 +8,7 @@ import fuzzaldrinPlus from 'fuzzaldrin-plus'
 export default class CommandPaletteView {
   constructor () {
     this.keyBindingsForActiveElement = []
-    this.elementCache = new WeakMap()
+    this.elementCache = new Map()
     this.selectListView = new SelectListView({
       items: [],
       filter: this.filter,
@@ -16,12 +16,13 @@ export default class CommandPaletteView {
       elementForItem: (item, {index, selected}) => {
         const query = this.selectListView.getQuery()
         const queryKey = `${query}:${selected}`
-        if(this.elementCache.has(item)) {
-          if(this.elementCache.get(item).has(queryKey)) {
-            return this.elementCache.get(item).get(queryKey)
+        const {name} = item
+        if(this.elementCache.has(name)) {
+          if(this.elementCache.get(name).has(queryKey)) {
+            return this.elementCache.get(name).get(queryKey)
           }
         } else {
-          this.elementCache.set(item, new Map())
+          this.elementCache.set(name, new Map())
         }
 
         const li = document.createElement('li')
@@ -74,7 +75,7 @@ export default class CommandPaletteView {
         }
 
         li.appendChild(leftBlock)
-        this.elementCache.get(item).set(queryKey, li)
+        this.elementCache.get(name).set(queryKey, li)
         return li
       },
       didConfirmSelection: (keyBinding) => {

--- a/test/command-palette-view.test.js
+++ b/test/command-palette-view.test.js
@@ -143,21 +143,23 @@ describe('CommandPaletteView', () => {
       const spy = sinon.spy(commandPalette.selectListView.props, 'elementForItem')
       await commandPalette.toggle()
       commandPalette.selectListView.items.forEach(item => {
+        const {name} = item
         const selected = commandPalette.selectListView.getSelectedItem() === item
         assert(spy.calledWithMatch(item))
-        assert(commandPalette.elementCache.has(item))
-        assert(commandPalette.elementCache.get(item).has(`:${selected}`))
-        assert(spy.returned(commandPalette.elementCache.get(item).get(`:${selected}`)))
+        assert(commandPalette.elementCache.has(name))
+        assert(commandPalette.elementCache.get(name).has(`:${selected}`))
+        assert(spy.returned(commandPalette.elementCache.get(name).get(`:${selected}`)))
       })
 
       spy.reset()
       await commandPalette.selectListView.update({query: 'Z'})
       commandPalette.selectListView.items.forEach(item => {
+        const {name} = item
         const selected = commandPalette.selectListView.getSelectedItem() === item
         assert(spy.calledWithMatch(item))
-        assert(commandPalette.elementCache.has(item))
-        assert(commandPalette.elementCache.get(item).has(`Z:${selected}`))
-        assert(spy.returned(commandPalette.elementCache.get(item).get(`Z:${selected}`)))
+        assert(commandPalette.elementCache.has(name))
+        assert(commandPalette.elementCache.get(name).has(`Z:${selected}`))
+        assert(spy.returned(commandPalette.elementCache.get(name).get(`Z:${selected}`)))
       })
     })
 
@@ -166,10 +168,35 @@ describe('CommandPaletteView', () => {
       const spy = sinon.spy(commandPalette.selectListView.props, 'elementForItem')
       await commandPalette.toggle()
       commandPalette.selectListView.selectIndex((commandPalette.selectListView.selectionIndex + 1), false)
-      const selectedItem = commandPalette.selectListView.getSelectedItem()
-      assert(!commandPalette.elementCache.get(selectedItem).has(':true'))
+      const selectedItemName = commandPalette.selectListView.getSelectedItem().name
+      assert(!commandPalette.elementCache.get(selectedItemName).has(':true'))
       await commandPalette.selectListView.update()
-      assert(commandPalette.elementCache.get(selectedItem).has(':true'))
+      assert(commandPalette.elementCache.get(selectedItemName).has(':true'))
+    })
+
+    it('uses cached elements when reactivating', async () => {
+      const commandPalette = new CommandPaletteView()
+      const spy = sinon.spy(commandPalette.selectListView.props, 'elementForItem')
+      await commandPalette.toggle()
+      commandPalette.selectListView.items.forEach(item => {
+        const {name} = item
+        const selected = commandPalette.selectListView.getSelectedItem() === item
+        assert(spy.calledWithMatch(item))
+        assert(commandPalette.elementCache.has(name))
+        assert(commandPalette.elementCache.get(name).has(`:${selected}`))
+        assert(spy.returned(commandPalette.elementCache.get(name).get(`:${selected}`)))
+      })
+      spy.reset()
+      await commandPalette.toggle()
+      await commandPalette.toggle()
+      commandPalette.selectListView.items.forEach(item => {
+        const {name} = item
+        const selected = commandPalette.selectListView.getSelectedItem() === item
+        assert(spy.calledWithMatch(item))
+        assert(commandPalette.elementCache.has(name))
+        assert(commandPalette.elementCache.get(name).has(`:${selected}`))
+        assert(spy.returned(commandPalette.elementCache.get(name).get(`:${selected}`)))
+      })
     })
   })
 


### PR DESCRIPTION
This PR fixes a problem from #94 where the item element cache was not utilized properly between palette toggles. 