### PR TITLE
Render on visible for better performance

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -6,14 +6,18 @@ import fuzzaldrin from 'fuzzaldrin'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
 export default class CommandPaletteView {
-  constructor () {
+  constructor (initiallyVisibleItemCount = 10) {
     this.keyBindingsForActiveElement = []
     this.elementCache = new WeakMap()
     this.selectListView = new SelectListView({
+      initiallyVisibleItemCount: initiallyVisibleItemCount, // just for being able to disable visible-on-render in spec
       items: [],
       filter: this.filter,
       emptyMessage: 'No matches found',
-      elementForItem: (item, {index, selected}) => {
+      elementForItem: (item, {index, selected, visible}) => {
+        if (!visible) {
+          return document.createElement("li")
+        }
         const query = this.selectListView.getQuery()
         const queryKey = `${query}:${selected}`
         if(this.elementCache.has(item)) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "atomTestRunner": "atom-mocha-test-runner",
   "dependencies": {
-    "atom-select-list": "^0.3.0",
+    "atom-select-list": "^0.7.0",
     "fuzzaldrin": "^2.1.0",
     "fuzzaldrin-plus": "^0.4.1",
     "underscore-plus": "^1.0.0"


### PR DESCRIPTION
### Description of the Change

[Updated]

Aiming to solve #80
Depends on https://github.com/atom/atom-select-list/pull/22

This PR use new atom select-list's `initiallyVisibleItemCount`(not merged yet) option.
When this option was passed, new `visible` option passed to `elementForItem` reflect visibility state in viewport.

We can use this information to skip heavy computation for faster response.
Here I just return empty `li` element when invisible.


Here is behavioral changes in `command-palette`.

- Old:
  - All items are equally rendered with command name, keymap shortcut.
- New:
  - First **10** items are always rendered with full info, others are just rendered with empty `li`.
  - When item become visible, render with full information(command name, shortcut)

### Alternate Designs

#81
#98
#97

### Benefits

Performance improve.
command-palette launch faster.

Perf comparison is at https://github.com/atom/atom-select-list/pull/22.

Plus, user can easily notice perf improvement especially for initial launch, and user have many commands(like installing `vim-mode-plus` or `nuculide`).

### Possible Drawbacks

When mouse scroll very quickly, user can see blank fake item.

### Applicable Issues

#80
