### PR TITLE
introduce numberOfRecentlyConfirmedCommandsShowsAtTop

### DIFF
--- a/lib/command-palette-package.js
+++ b/lib/command-palette-package.js
@@ -21,6 +21,9 @@ class CommandPalettePackage {
     this.disposables.add(atom.config.observe('command-palette.preserveLastSearch', (newValue) => {
       this.commandPaletteView.update({preserveLastSearch: newValue})
     }))
+    this.disposables.add(atom.config.observe('command-palette.numberOfRecentlyConfirmedCommandsShowsAtTop', (newValue) => {
+      this.commandPaletteView.update({numberOfRecentlyConfirmedCommandsShowsAtTop: newValue})
+    }))
     return this.commandPaletteView.show()
   }
 

--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -5,9 +5,16 @@ import {humanizeKeystroke} from 'underscore-plus'
 import fuzzaldrin from 'fuzzaldrin'
 import fuzzaldrinPlus from 'fuzzaldrin-plus'
 
+function removeItemBy (list, fn) {
+  const index = list.findIndex(fn)
+  if (index !== -1) list.splice(index, 1)
+}
+
 export default class CommandPaletteView {
   constructor (initiallyVisibleItemCount = 10) {
     this.keyBindingsForActiveElement = []
+    this.recentlyConfirmedCommands = []
+    this.numberOfRecentlyConfirmedCommandsShowsAtTop = 0
     this.elementCache = new WeakMap()
     this.selectListView = new SelectListView({
       initiallyVisibleItemCount: initiallyVisibleItemCount, // just for being able to disable visible-on-render in spec
@@ -85,6 +92,9 @@ export default class CommandPaletteView {
         return li
       },
       didConfirmSelection: (keyBinding) => {
+        if (this.numberOfRecentlyConfirmedCommandsShowsAtTop > 0) {
+          this.updateRecentlyConfirmedCommands(keyBinding)
+        }
         this.hide()
         const event = new CustomEvent(keyBinding.name, {bubbles: true, cancelable: true})
         this.activeElement.dispatchEvent(event)
@@ -126,7 +136,21 @@ export default class CommandPaletteView {
         .findCommands({target: this.activeElement})
         .filter(command => showHiddenCommands === !!command.hiddenInCommandPalette)
     commandsForActiveElement.sort((a, b) => a.displayName.localeCompare(b.displayName))
-    await this.selectListView.update({items: commandsForActiveElement})
+
+    if (this.numberOfRecentlyConfirmedCommandsShowsAtTop > 0) {
+      for (const command of this.recentlyConfirmedCommands) {
+        // NOTE: items lifted to top should not be returned from cache.
+        // Since cached element which already attached to DOM need to be stable.
+        this.elementCache.delete(command)
+        // When package have activationCommands, `command` object is replaced after initial invocation.
+        // So we can't simply use `commandsForActiveElement.indexOf(command)`.
+        removeItemBy(commandsForActiveElement, item => item.name === command.name)
+      }
+      await this.selectListView.update({items: [...this.recentlyConfirmedCommands, ...commandsForActiveElement]})
+    } else {
+      await this.selectListView.update({items: commandsForActiveElement})
+    }
+
 
     this.previouslyFocusedElement = document.activeElement
     this.panel.show()
@@ -148,6 +172,11 @@ export default class CommandPaletteView {
 
     if (props.hasOwnProperty('useAlternateScoring')) {
       this.useAlternateScoring = props.useAlternateScoring
+    }
+
+    if (props.hasOwnProperty('numberOfRecentlyConfirmedCommandsShowsAtTop')) {
+      this.numberOfRecentlyConfirmedCommandsShowsAtTop = props.numberOfRecentlyConfirmedCommandsShowsAtTop
+      this.updateRecentlyConfirmedCommands()
     }
   }
 
@@ -266,5 +295,13 @@ export default class CommandPaletteView {
       }
     })
     return tagsEl
+  }
+
+  updateRecentlyConfirmedCommands (command) {
+    if (command) {
+      removeItemBy(this.recentlyConfirmedCommands, item => item.name === command.name)
+      this.recentlyConfirmedCommands = [command, ...this.recentlyConfirmedCommands]
+    }
+    this.recentlyConfirmedCommands.splice(this.numberOfRecentlyConfirmedCommandsShowsAtTop)
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
       "type": "boolean",
       "default": false,
       "description": "Preserve the last search when reopening the command palette."
+    },
+    "numberOfRecentlyConfirmedCommandsShowsAtTop": {
+      "type": "integer",
+      "default": 0,
+      "description": "Specified number of recently confirmed commands appears at top of command list."
     }
   }
 }


### PR DESCRIPTION
### Description of the Change

Fix #18

There is already PR #86, #87.
This PR somewhat takeover of #86.

Introduce new configuration `numberOfRecentlyConfirmedCommandsShowsAtTop`(default 0).
When set to greater than 0, it shows specified number of recently confirmed commands at top of list.
So user can simply confirm last confirmed item by "`cmd-shift-p` then `enter`".

Why I send this PR when there is already similar PRs in the queue is, I think this PR's implementation is more straightforward in implementation(just move recent items to top of command array on `show()` timing).

## Why invalidation of cached element is important

If we return cached element for item which is moved to top of list, it breaks at here.

https://github.com/atom/atom-select-list/blob/ee325e75833acc84af9f9c90aed30157e1816f36/src/select-list-view.js#L449

`atom-select-list#ListItemView::update()` does directly manipulate DOM element by `replaceChild` which assume `this.element` is stable at position in `<ol>`.

### Alternate Designs

#86, #87

### Benefits

Described in #18.
When user want to invoke last confirmed again, it's possible by just "`cmd-shift-p` then `enter`" workflow.

### Possible Drawbacks

None.

### Applicable Issues

#18
