### PR TITLE
Skip item element cache when search is preserved

### DIFF
--- a/lib/command-palette-view.js
+++ b/lib/command-palette-view.js
@@ -21,7 +21,7 @@ export default class CommandPaletteView {
         const query = this.selectListView.getQuery()
         const queryKey = `${query}:${selected}`
         if(this.elementCache.has(item)) {
-          if(this.elementCache.get(item).has(queryKey)) {
+          if(!this.preserveLastSearch && this.elementCache.get(item).has(queryKey)) {
             return this.elementCache.get(item).get(queryKey)
           }
         } else {


### PR DESCRIPTION
### Description of the Change

This change works around an issue introduced in 0.43.0 which causes the
command palette to become unusable when the user enables the "Preserve
Last Search" setting and then searches a few times.  This is caused by
the new item element caching logic which preserves items from previous
searches.  Somehow these cached elements do not have their parentNode
set to the SelectListView causing the crash which breaks the command
palette.

This change is a temporary workaround to unblock the release of Atom
1.24 and 1.25-beta until the core issue can be addressed.

Related to atom/atom#16622.

### Alternate Designs

Another approach was to add a null check around the use of `parentNode.replaceChild` in atom-select-list, but this caused other UX problems to occur.  The better workaround is to avoid the broken elements to begin with.  A real fix that addresses the core problem is still needed, but this change unblocks the release of 1.24 and 1.25-beta.

### Benefits

No more crashing command palette which can only be resolved by restarting Atom.

### Possible Drawbacks

Reduced performance when "Preserve Last Search" is turned on.

### Applicable Issues

atom/atom#16622

/cc @iolsen @lee-dohm @Ben3eeE @as-cii 